### PR TITLE
Fix CI tables rendering

### DIFF
--- a/docs/1.0. Architecture.md
+++ b/docs/1.0. Architecture.md
@@ -147,6 +147,7 @@ Figure 7 shows a sequence diagram for setting up a connection between an IPMX En
 | *Figure 7. Sequence Diagram for User-Story 1 from NMOS Perspective* |
 
 Table 3: Details for Sequence Diagram Steps for Figure 6
+
 | Sequence Step | Description | Notes |
 | ---  | ---         | ---         |
 | 1: Choose Sender and Receiver | The PRO AV Person interacts with the IPMX Control System to choose a set of receivers for a sender. | |


### PR DESCRIPTION
Now CI renders Table 3 as plain text which is caused by absent newline between it and its caption.