### PR TITLE
Technical and editorial changes from review the EDID to Rx Caps mapping

### DIFF
--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -111,11 +111,15 @@ For example, given the three bytes of Established Timings I & II were `20 08 00`
 
 #### Standard Timings
 
-Standard Timing format is defined in [E-EDID][E-EDID] section 3.9. The mapping is as follows:
+Standard Timing Definitions (STD) format is defined in [E-EDID][E-EDID] section 3.9. The mapping is as follows:
 
 * `urn:x-nmos:cap:format:frame_width` MUST be calculated from the _Horizontal Active Pixel Count_
 * `urn:x-nmos:cap:format:frame_height` MUST be calculated using the _Frame Width_ and _Image Aspect Ratio_
 * `urn:x-nmos:cap:format:grain_rate` MUST be calculated with _Field Refresh Rate_
+
+Additionally, defined in [DMT][DMT] section 1 are the interlace mode for (STD) codes
+
+* `urn:x-nmos:cap:format:interlace_mode` MUST be set according Table 1-1 Standards and Guidelines
 
 <details><summary>Example: Standard Timings</summary>
 
@@ -129,6 +133,9 @@ For example, given the bytes of Standard Timings were `D1 C0 01 01 01 01 01 01 0
     },
     "urn:x-nmos:cap:format:frame_height": {
       "enum": [ 1920 ]
+    },
+    "urn:x-nmos:cap:format:interlace_mode": {
+      "enum": [ "progressive" ]
     },
     "urn:x-nmos:cap:format:grain_rate": {
       "enum": [ { "numerator": 60 } ]
@@ -165,7 +172,7 @@ Each _Supported Vertical Rate_, except _Preferred Vertical Rate_, MUST be extrac
 
 #### DMT Standard Codes & IDs Summary
 
-DMT Codes are used to augment the Standard Timing Descriptors and CVT Codes, for some EDID IDs extra calcuations are REQUIRED to obtain the frame rate as per [DMT][DMT] section 2 and section 4.
+DMT Codes are used to augment the Standard Timing Descriptors and CVT Codes for some EDID IDs. Extra calcuations are REQUIRED to obtain the exact frame rate as per [DMT][DMT] section 2 and section 4.
 
 * `urn:x-nmos:cap:format:grain_rate` MUST be calculated and represent the exact frame rate. The rational MUST be reduced to the smallest possible numerator.
 

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -43,7 +43,7 @@ The mapping is affected when a Gateway Device is:
 - constrained beyond the capabilities of the Sink (e.g. it suports resolution up to 1080 but is connected to a 4k monitor)
 - using any internal processing before pasing the signal to the Sink (e.g. support multiple Sinks per Receiver and use greatest common denominator to constrain itself) 
 
-The Gatewat Device MUST include any types of conversion, omit any restrictions, or reflect the internal processing in the capabilities of the Receiver.
+The Gateway Device MUST include any types of conversion, omit any restrictions, or reflect the internal processing in the capabilities of the Receiver.
 
 ## Video Receivers
 
@@ -141,7 +141,7 @@ For example, given the bytes of Standard Timings were `D1 C0 01 01 01 01 01 01 0
 
 #### Detailed Timing Descriptors (18 Byte Descriptors)
 
-Defined in [E-EDID][E-EDID] section 3.10, there a 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value off `100`.
+Defined in [E-EDID][E-EDID] section 3.10, there a 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value of `100`.
 
 The mapping is defined in section 3.10.2 and is applied as follows:
 
@@ -165,9 +165,9 @@ Each _Supported Vertical Rate_, except _Preferred Vertical Rate_, MUST be extrac
 
 #### DMT Standard Codes & IDs Summary
 
-DMT Code are used to augement the Standard Timining Descriptors and CTV Codes, for some EDID IDs extra calcuations are REQUIRED to obtain the frame rate as per [DMT][DMT] section 2 and section 4.
+DMT Codes are used to augment the Standard Timing Descriptors and CVT Codes, for some EDID IDs extra calcuations are REQUIRED to obtain the frame rate as per [DMT][DMT] section 2 and section 4.
 
-* `urn:x-nmos:cap:format:grain_rate` MUST be calcuated and represent tge exact frame rate. The rational MAY be reduced by its greatest common denominator.
+* `urn:x-nmos:cap:format:grain_rate` MUST be calculated and represent the exact frame rate. The rational MAY be reduced by its greatest common denominator.
 
 <details><summary>Example: DMT Standard Codes</summary>
 
@@ -236,7 +236,7 @@ When no descriptors are provided, the cabilities MUST contain:
 If there are Short Audio Descriptors (see [CTA-861][CTA-861] section 7.5.2), then each of them MUST be transformed into a Constraint Set.
 
 * `urn:x-nmos:cap:format:media_type` MUST be determined with _Audio Format Code_
-  * Linear PCM bit depth MUST be the third Short Audio Descriptors byte
+  * Linear PCM bit depth MUST be taken from the third Short Audio Descriptors byte
 * `urn:x-nmos:cap:format:channel_count` MUST be determined by _Number of Channels_
 * `urn:x-nmos:cap:format:sample_rate` MUST be filled with _Sampling Frequencies_
 

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -36,7 +36,7 @@ A media consuming unit described by an EDID which can be associated to a Receive
 
 ## Introduction
 
-Gateway Devices which bridge a NMOS Receivers to baseband connection need to expose the capabilities of the baseband interface through the NMOS resouce to enable connection management. This can be obtained by mapping a Sink's EDID to a Receiver's Capabilities and factoring the abilities of the Gateway Device.
+Gateway Devices which bridge a NMOS Receivers to baseband connection need to expose the capabilities of the baseband interface through the NMOS resource to enable connection management. This can be obtained by mapping a Sink's EDID to a Receiver's Capabilities and factoring the abilities of the Gateway Device.
 
 The mapping is affected when a Gateway Device is:
 - capable of altering a signal (e.g. it is able to consume 4K and downscale it for the Sink who supports up to HD resolutions)

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -167,7 +167,7 @@ Each _Supported Vertical Rate_, except _Preferred Vertical Rate_, MUST be extrac
 
 DMT Codes are used to augment the Standard Timing Descriptors and CVT Codes, for some EDID IDs extra calcuations are REQUIRED to obtain the frame rate as per [DMT][DMT] section 2 and section 4.
 
-* `urn:x-nmos:cap:format:grain_rate` MUST be calculated and represent the exact frame rate. The rational MAY be reduced by its greatest common denominator.
+* `urn:x-nmos:cap:format:grain_rate` MUST be calculated and represent the exact frame rate. The rational MUST be reduced to the smallest possible numerator.
 
 <details><summary>Example: DMT Standard Codes</summary>
 
@@ -178,8 +178,7 @@ For example, the EDID with ID `DMT ID: 45h; Std. 2 Byte Code: (D1, 00)h; CVT 3 B
   {
     "urn:x-nmos:cap:format:grain_rate": {
       "enum": [
-        { "numerator": 192250000, "denominator": 3227040 }, // Equals the framte rate of 59.885
-        { "numerator": 2403125, "denominator": 40338 }      // When reduced by GCD of 80
+        { "numerator": 2403125, "denominator": 40338 } // When reduced by GCD of 80
       ]
     }
   }

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -208,19 +208,15 @@ It has one of four possible values:
 * RGB 4:4:4 & YCbCr 4:2:2
 * RGB 4:4:4 & YCbCr 4:4:4 & YCbCr 4:2:2
 
-This value MUST be transformed into `urn:x-nmos:cap:format:color_sampling` with `enum` type values added to each Constraint Set.
+This value MUST be transformed into `urn:x-nmos:cap:format:color_sampling` with `enum` values according to those permitted by the [NMOS Parameter Registers - Capabilities][NMOS Capabilities] section and added to each Constraint Set.
 
 #### CTA-861 Extension Block
 
-The origin of supported color subsampling formats in CTA-861 is CTA Extension Header ([CTA-861][CTA-861] section 7.5). Bits 4 and 5 of byte 3 show whether Sink supports `YCbCr 4:2:2` and `YCbCr 4:4:4` respectively in addition to RGB.
+The supported color subsampling formats in the CTA Extension Header ([CTA-861][CTA-861] section 7.5) indicates whether the Sink supports `YCbCr-4:2:2` and `YCbCr-4:4:4` respectively in addition to `RGB`.
 
-`YCbCr 4:2:0` Capability Map Data Block ([CTA-861][CTA-861] section 7.5.11) shows which timings support `YCbCr 4:2:0` in addition to subsampling formats listed in CTA Extension Header.
+Capability Map Data Block ([CTA-861][CTA-861] section 7.5.11) shows which timings support `YCbCr-4:2:0` in addition to subsampling formats listed in CTA Extension Header. These timings MUST contain `YCbCr-4:2:0` within the possible values for `urn:x-nmos:cap:format:color_sampling` with associated Constraint Set.
 
-These values MUST be transformed into `urn:x-nmos:cap:format:color_sampling` with `enum` type value and added to each Constraint Set.
-
-`YCbCr 4:2:0` Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks timings as supporting only `YCbCr 4:2:0`.
-
-Constraint Set associated with these timings MUST have `urn:x-nmos:cap:format:color_sampling` equal to `YCbCr-4:2:0`.
+Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks timings as supporting only `YCbCr-4:2:0`. Constraint Set associated with these timings MUST have `urn:x-nmos:cap:format:color_sampling` limited to `YCbCr-4:2:0`.
 
 ## Audio Receivers
 
@@ -242,7 +238,8 @@ If there are Short Audio Descriptors (see [CTA-861][CTA-861] section 7.5.2), the
 
 [RFC-2119]: https://tools.ietf.org/html/rfc2119 "Key words for use in RFCs to Indicate Requirement Levels"
 [IS-04]: https://specs.amwa.tv/is-04/ "AMWA IS-04 NMOS Discovery and Registration Specification (Stable)"
-[BCP-004-01]: https://specs.amwa.tv/bcp-004-01/ "NMOS Receiver Capabilities"
+[BCP-004-01]: https://specs.amwa.tv/bcp-004-01/ "AMWA NMOS Receiver Capabilities"
+[NMOS Capabilities]: https://github.com/AMWA-TV/nmos-parameter-registers/blob/main/capabilities/README.md "AMWA NMOS Parameter Registers - NMOS Capabilities"
 [E-EDID]: https://vesa.org/vesa-standards/ "VESA Enhanced Extended Display Identification Data Standard Release A, Revision 2"
 [DMT]: https://vesa.org/vesa-standards/ "VESA and Industry Standards and Guidelines for Computer Display Monitor Timing (DMT) Version 1.0, Rev. 12"
 [CTA-861]: https://shop.cta.tech/products/a-dtv-profile-for-uncompressed-high-speed-digital-interfaces-cta-861-g "A DTV Profile for Uncompressed High Speed Digital Interfaces (CTA-861-G)"

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -214,9 +214,9 @@ This value MUST be transformed into `urn:x-nmos:cap:format:color_sampling` with 
 
 The supported color subsampling formats in the CTA Extension Header ([CTA-861][CTA-861] section 7.5) indicates whether the Sink supports `YCbCr-4:2:2` and `YCbCr-4:4:4` respectively in addition to `RGB`.
 
-Capability Map Data Block ([CTA-861][CTA-861] section 7.5.11) shows which timings support `YCbCr-4:2:0` in addition to subsampling formats listed in CTA Extension Header. These timings MUST contain `YCbCr-4:2:0` within the possible values for `urn:x-nmos:cap:format:color_sampling` with associated Constraint Set.
+YCbCr 4:2:0 Capability Map Data Block ([CTA-861][CTA-861] section 7.5.11) shows which timings support `YCbCr-4:2:0` in addition to subsampling formats listed in CTA Extension Header. These timings MUST contain `YCbCr-4:2:0` within the possible values for `urn:x-nmos:cap:format:color_sampling` with associated Constraint Set.
 
-Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks timings as supporting only `YCbCr-4:2:0`. Constraint Set associated with these timings MUST have `urn:x-nmos:cap:format:color_sampling` limited to `YCbCr-4:2:0`.
+YCbCr 4:2:0 Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks timings as supporting only `YCbCr-4:2:0`. Constraint Set associated with these timings MUST have `urn:x-nmos:cap:format:color_sampling` limited to `YCbCr-4:2:0`.
 
 ## Audio Receivers
 

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -141,7 +141,7 @@ For example, given the bytes of Standard Timings were `D1 C0 01 01 01 01 01 01 0
 
 #### Detailed Timing Descriptors (18 Byte Descriptors)
 
-Defined in [E-EDID][E-EDID] section 3.10, there are 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value of `100`. Any additional Detailed Timing Descriptors in [CTA-861][CTA-861] Extension BLock (section 7.2.1) MUST follow the mapping.
+Defined in [E-EDID][E-EDID] section 3.10, there are 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value of `100`. Any Detailed Timing Descriptors in [CTA-861][CTA-861] Extension BLock (section 7.2.1) MUST follow the mapping.
 
 The mapping is defined in section 3.10.2 and is applied as follows:
 

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -141,7 +141,7 @@ For example, given the bytes of Standard Timings were `D1 C0 01 01 01 01 01 01 0
 
 #### Detailed Timing Descriptors (18 Byte Descriptors)
 
-Defined in [E-EDID][E-EDID] section 3.10, there a 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value of `100`. Any additional Detailed Timing Descriptors in [CTA-861][CTA-861] Extension BLock (section 7.2.1) MUST follow the mapping.
+Defined in [E-EDID][E-EDID] section 3.10, there are 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value of `100`. Any additional Detailed Timing Descriptors in [CTA-861][CTA-861] Extension BLock (section 7.2.1) MUST follow the mapping.
 
 The mapping is defined in section 3.10.2 and is applied as follows:
 

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -43,7 +43,7 @@ The mapping is affected when a Gateway Device is:
 - constrained beyond the capabilities of the Sink (e.g. it suports resolution up to 1080 but is connected to a 4k monitor)
 - using any internal processing before pasing the signal to the Sink (e.g. support multiple Sinks per Receiver and use greatest common denominator to constrain itself) 
 
-The Gateway Device MUST include any types of conversion, omit any restrictions, or reflect the internal processing in the capabilities of the Receiver.
+The Gateway Device SHALL include any types of conversion, omit any restrictions, or reflect the internal processing in the capabilities of the Receiver.
 
 ## Video Receivers
 

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -1,18 +1,26 @@
-# AMWA BCP-XXX-YY: EDID to NMOS Receiver Caps Mapping
+# AMWA BCP-XXX-YY: EDID to NMOS Receiver Capabilities Mapping \[Work In Progress\]
 
-## Background
+{:.no_toc}
 
-Extended Display Identification Data (EDID) is a metadata format for sink devices to describe their capabilities to a video source (e.g. graphics card or set-top box). The data format is defined by a standard published by the Video Electronics Standards Association (VESA). This document is targeted against [E-EDID A2][E-EDID] files which consist of EDID 1.4 which is called Base EDID and an optional [CTA-861-G][CTA-861] Extension Block.
+* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
 
-[AMWA BCP-004-01][BCP-004-01] describes a methodology for a similar purpose in relationship to [AMWA IS-04][IS-04].
+{:toc}
+
+Extended Display Identification Data (EDID) is a metadata format for an apparatus to describe its capabilities as a video source (e.g. graphics card or set-top box). The data format is defined by a standard published by the Video Electronics Standards Association (VESA). This document is targeted against [E-EDID A2][E-EDID] which consist of EDID 1.4 (and covers EDID 1.3) and is refered to as _Base EDID_ and the [CTA-861-G][CTA-861] Extension Block imposed by HDMI. The information present in the EDID is subject to the requirements of the [Display Monitor Timing (DMT)][DMT] specification Version 1 Rev 12.
+
+Similarly, [BCP-004-01][BCP-004-01] Receiver Capabilities defines a methodology for describing the Receivers with constraints on the properties of streams which related to [IS-04][IS-04] Senders.
 
 ## Scope
 
-This document provides Best Current Practice guidelines for how to implement a mapping of EDID fields to Receiver Capabilities in order to have a specific way of representing an EDID sink devices through an associated IS-04 Receiver.
+This document provides Best Current Practice guidelines for how to implement a mapping of EDID fields to Receiver Capabilities in order to have a specific way of representing an EDID sink devices through an associated [IS-04][IS-04] Receiver.
 
 ## Use of Normative Language
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][RFC-2119].
+
+## Normative References
+
+These appear at the end of the Markdown source for this document, and are referenced as hyperlinks within the main body.
 
 ## Definitions
 
@@ -20,65 +28,165 @@ _See also the [NMOS Glossary](https://specs.amwa.tv/nmos/branches/main/docs/4.0.
 
 ### Gateway Device
 
-A device which encapsulates a digital video or/and audio signal (usually, from a physical connection) into IP packets. Conversely, the device may perform the reverse operation for IP packets to a digital signal.
+A device which encapsulates a digital video or/and audio signal (usually, from a physical connection) into IP packets. Conversely, the device MAY perform the reverse operation for IP packets to a digital signal.
 
 ### Sink
 
-A media consuming unit associated with an IS-04 Receiver.
+A media consuming unit described by an EDID which can be associated to a Receiver.
 
 ## Introduction
 
-The mapping of a Sink's EDID to a Receiver's Capabilities is limited to Devices that treat signals as immutable. Devices capable of altering a signal MUST reflect the capabilities of the Receiver including any types of conversion or restrictions. Devices which support multiple Sinks per Receiver MUST expose the capabilities of the Receiver if any internal processing occures (e.g. the Receiver is able to consume 4K Flow and downscale it for the Sink who's EDID describes support up to HD resolutions).
+Gateway Devices which bridge a NMOS Receivers to baseband connection need to expose the capabilities of the baseband interface through the NMOS resouce to enable connection management. This can be obtained by mapping a Sink's EDID to a Receiver's Capabilities and factoring the abilities of the Gateway Device.
+
+The mapping is affected when a Gateway Device is:
+- capable of altering a signal (e.g. it is able to consume 4K and downscale it for the Sink who supports up to HD resolutions)
+- constrained beyond the capabilities of the Sink (e.g. it suports resolution up to 1080 but is connected to a 4k monitor)
+- using any internal processing before pasing the signal to the Sink (e.g. support multiple Sinks per Receiver and use greatest common denominator to constrain itself) 
+
+The Gatewat Device MUST include any types of conversion, omit any restrictions, or reflect the internal processing in the capabilities of the Receiver.
 
 ## Video Receivers
 
-If an IS-04 Video Receiver is associated with a Sink which has EDID, its video capabilities MUST be mapped into Receiver's Capabilities accordingly to the rules below.
+If an [IS-04][IS-04] Video Receiver is associated with a Sink which has EDID, its supported video formats MUST be mapped into Receiver's Capabilities according to the rules below.
 
 ### Video timings
 
-Video timings, described in E-EDID, provide information about video frame size and rate.
+Video timings, described in [E-EDID][E-EDID], provide information about video frame size and rate. There are multiple blocks which keep information about timings each with their own mapping requirements.
 
-Each video timing MUST be present in Receiver Capabilities as a Constraint Set with non-empty `urn:x-nmos:cap:format:frame_width`, `urn:x-nmos:cap:format:frame_height` and `urn:x-nmos:cap:format:grain_rate` fields. There are multiple E-EDID blocks which keep information about timings each with their own mapping requirements.
+Each video timing SHOULD be present in the Receiver's Capabilities as a Constraint Set with a non-empty
 
-#### Established Timings
+* `urn:x-nmos:cap:format:frame_width`
+* `urn:x-nmos:cap:format:frame_height`
+* `urn:x-nmos:cap:format:grain_rate` which MUST be the frame rate of the signal
 
-There are three sets of timings of this type: Established Timings I, II & III. The first two types are defined in [E-EDID][E-EDID] section 3.8, the last - in [E-EDID][E-EDID] section 3.10.3.9.
+The timing descriptors MAY include one or more of the following mappings:
 
-Each Established Timing is an ID associated with a union of frame width, height and rate and interlace mode, and the mentioned sections define this mapping.
+* `urn:x-nmos:cap:format:interlace_mode`
+* `urn:x-nmos:cap:meta:preference`
+
+Video timings with _Reduced Blanking_ MAY be determined by the exact `urn:x-nmos:cap:format:grain_rate`.
+
+#### Established Timings I, II & III
+
+Each Established Timing is an ID associated with a predefined frame width, height and rate and interlace mode. Mapping the first two types are defined in [E-EDID][E-EDID] section 3.8 and the last in [E-EDID][E-EDID] section 3.10.3.9.
+
+<details><summary>Example: Established Timings I & II</summary>
+
+For example, given the three bytes of Established Timings I & II were `20 08 00` then the receiver capabilies could contain the following in its constraint sets
+
+```json
+[
+  {
+    "urn:x-nmos:cap:format:frame_width": {
+      "enum": [ 640 ]
+    },
+    "urn:x-nmos:cap:format:frame_height": {
+      "enum": [ 480 ]
+    },
+    "urn:x-nmos:cap:format:interlace_mode": {
+      "enum": [ "progressive" ]
+    },
+    "urn:x-nmos:cap:format:grain_rate": {
+      "enum": [ { "numerator": 60 } ]
+    }
+  },
+  {
+    "urn:x-nmos:cap:format:frame_width": {
+      "enum": [ 1024 ]
+    },
+    "urn:x-nmos:cap:format:frame_height": {
+      "enum": [ 768 ]
+    },
+    "urn:x-nmos:cap:format:interlace_mode": {
+      "enum": [ "progressive" ]
+    },
+    "urn:x-nmos:cap:format:grain_rate": {
+      "enum": [ { "numerator": 60 } ]
+    }
+  }
+]
+```
+
+</details>
 
 #### Standard Timings
 
-Standard Timing format is defined in [E-EDID][E-EDID] section 3.9.
+Standard Timing format is defined in [E-EDID][E-EDID] section 3.9. The mapping is as follows:
 
-Frame width MUST be calculated using the following formula: Frame width = (1B + 31) × 8, where 1B is the 1st byte of a Standard Timing. It MUST go into `urn:x-nmos:cap:format:frame_width`.
+* `urn:x-nmos:cap:format:frame_width` MUST be calculated from the _Horizontal Active Pixel Count_
+* `urn:x-nmos:cap:format:frame_height` MUST be calculated using the _Frame Width_ and _Image Aspect Ratio_
+* `urn:x-nmos:cap:format:grain_rate` MUST be calculated with _Field Refresh Rate_
 
-Frame height MUST be calculated using the following formula: Frame height = FW / IAR, where FW is Frame width and IAR is _Image Aspect Ratio_, and go into `urn:x-nmos:cap:format:frame_height`.
+<details><summary>Example: Standard Timings</summary>
 
-Frame rate is named _Field Refresh Rate_ there and MUST go into `urn:x-nmos:cap:format:grain_rate`.
+For example, given the bytes of Standard Timings were `D1 C0 01 01 01 01 01 01 01 01 01 01 01` then the receiver capabilies could contain the following in its constraint sets
 
-#### 18 Byte Descriptors (Detailed Timing Descriptors)
+```json
+[
+  {
+    "urn:x-nmos:cap:format:frame_width": {
+      "enum": [ 1080 ]
+    },
+    "urn:x-nmos:cap:format:frame_height": {
+      "enum": [ 1920 ]
+    },
+    "urn:x-nmos:cap:format:grain_rate": {
+      "enum": [ { "numerator": 60 } ]
+    }
+  }
+]
+```
 
-Detailed Timing Descriptor is defined in [E-EDID][E-EDID] section 3.10.2.
+</details>
 
-Frame width is named _Horizontal Addressable Video in pixels_ there and MUST go into `urn:x-nmos:cap:format:frame_width`.
+#### Detailed Timing Descriptors (18 Byte Descriptors)
 
-Frame height is named _Vertical Addressable Video in lines_ there and MUST go into `urn:x-nmos:cap:format:frame_height`. If timing is interlaced, then _Vertical Addressable Video in lines_ MUST be multiplied by 2.
+Defined in [E-EDID][E-EDID] section 3.10, there a 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value off `100`.
 
-Frame rate MUST be calculated using the following formula: Frame rate = PC × 10,000 / ((HAV + HB) × (VAV + VB)), where PC is _Pixel Clock_, HAV - _Horizontal Addressable Video in pixels_, HB - _Horizontal Blanking in pixels_, VAV - _Vertical Addressable Video in lines_ and VB - _Vertical Blanking in lines_. If a fraction, MUST be rounded to 2 significant digits after the point and go into `urn:x-nmos:cap:format:grain_rate`.
+The mapping is defined in section 3.10.2 and is applied as follows:
 
-Interlace mode is named _Signal Interface Type_ there and MUST go into `urn:x-nmos:cap:format:interlace_mode`.
+* `urn:x-nmos:cap:format:interlace_mode` MUST be set according to _Signal Interface Type_ defined in table 3.22
+* `urn:x-nmos:cap:format:frame_width` MUST be _Horizontal Addressable Video in pixels_
+* `urn:x-nmos:cap:format:frame_height` MUST be calculated using the _Vertical Addressable Video in lines_ which MUST be multiplied by 2 when _Signal Interface Type_ indicates interlaced
+* `urn:x-nmos:cap:format:grain_rate` SHALL be accurately represented by
+  * `numerator` MUST be calculated using _Pixel Clock_
+  * `denominator` MUST be calculated with _Horizontal Addressable Video in pixels_, _Horizontal Blanking in pixels_, _Vertical Addressable Video in lines_ and _Vertical Blanking in lines_
 
 #### 3 Byte CVT Codes
 
 3 Byte CVT Code structure is defined in [E-EDID][E-EDID] section 3.10.3.8.
 
-Frame height MUST be calculated using the following formula: Frame height = (12BV + 1) × 2, where 12BV is the 12 bit value of a CVT Code. It MUST go into `urn:x-nmos:cap:format:frame_height`.
+* `urn:x-nmos:cap:format:frame_height` MUST be calculated using value of the CVT Code
+* `urn:x-nmos:cap:format:frame_width` MUST be calculated with Frame Height and _Aspect Ratio_
 
-Frame width MUST be calculated using the following formula: Frame width = 8 × ROUNDDOWN(FH × AR / 8) where FH is Frame Height, AR is _Aspect Ratio_ and ROUNDDOWN is rounding down to the nearest integer. It MUST go into `urn:x-nmos:cap:format:frame_width`.
+_Preferred Vertical Rate_ united with the frame width and height makes a Constraint Set and SHOULD have a `urn:x-nmos:cap:meta:preference` value off `50`
 
-_Preferred Vertical Rate_ united with the frame width and height makes a Constraint Set.
+Each _Supported Vertical Rate_, except _Preferred Vertical Rate_, MUST be extracted to a new Constraint Set with the same frame width and height.
 
-Each _Supported Vertical Rate_ except the same value as _Preferred Vertical Rate_ MUST be extracted to a new Constraint Set with the same frame width and height.
+#### DMT Standard Codes & IDs Summary
+
+DMT Code are used to augement the Standard Timining Descriptors and CTV Codes, for some EDID IDs extra calcuations are REQUIRED to obtain the frame rate as per [DMT][DMT] section 2 and section 4.
+
+* `urn:x-nmos:cap:format:grain_rate` MUST be calcuated and represent tge exact frame rate. The rational MAY be reduced by its greatest common denominator.
+
+<details><summary>Example: DMT Standard Codes</summary>
+
+For example, the EDID with ID `DMT ID: 45h; Std. 2 Byte Code: (D1, 00)h; CVT 3 Byte Code: (57, 28, 28)h` then the receiver capabilies could contain the following in its constraint sets
+
+```jsonc
+[
+  {
+    "urn:x-nmos:cap:format:grain_rate": {
+      "enum": [
+        { "numerator": 192250000, "denominator": 3227040 }, // Equals the framte rate of 59.885
+        { "numerator": 2403125, "denominator": 40338 }      // When reduced by GCD of 80
+      ]
+    }
+  }
+]
+```
+
+</details>
 
 #### Video Data Block
 
@@ -92,7 +200,7 @@ If EDID doesn't have the [CTA-861][CTA-861] Extension Block, color subsampling f
 
 #### Base EDID
 
-The origin of supported color subsampling formats in Base EDID is the Feature Support byte ([E-EDID A2][E-EDID] section 3.6.4).
+The origin of supported color subsampling formats in Base EDID is the Feature Support in [E-EDID A2][E-EDID] section 3.6.4.
 
 It has one of four possible values:
 * RGB 4:4:4
@@ -100,49 +208,41 @@ It has one of four possible values:
 * RGB 4:4:4 & YCbCr 4:2:2
 * RGB 4:4:4 & YCbCr 4:4:4 & YCbCr 4:2:2
 
-This value MUST be transformed into `urn:x-nmos:cap:format:color_sampling` with `enum` type value and added to each Constraint Set.
+This value MUST be transformed into `urn:x-nmos:cap:format:color_sampling` with `enum` type values added to each Constraint Set.
 
 #### CTA-861 Extension Block
 
-The origin of supported color subsampling formats in CTA-861 is CTA Extension Header ([CTA-861][CTA-861] section 7.5). Bits 4 and 5 of byte 3 show whether Sink supports YCbCr 4:2:2 and YCbCr 4:4:4 respectively in addition to RGB.
+The origin of supported color subsampling formats in CTA-861 is CTA Extension Header ([CTA-861][CTA-861] section 7.5). Bits 4 and 5 of byte 3 show whether Sink supports `YCbCr 4:2:2` and `YCbCr 4:4:4` respectively in addition to RGB.
 
-YCbCr 4:2:0 Capability Map Data Block ([CTA-861][CTA-861] section 7.5.11) shows which timings support YCbCr 4:2:0 in addition to subsampling formats listed in CTA Extension Header.
+`YCbCr 4:2:0` Capability Map Data Block ([CTA-861][CTA-861] section 7.5.11) shows which timings support `YCbCr 4:2:0` in addition to subsampling formats listed in CTA Extension Header.
 
 These values MUST be transformed into `urn:x-nmos:cap:format:color_sampling` with `enum` type value and added to each Constraint Set.
 
-YCbCr 4:2:0 Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks timings as supporting only YCbCr 4:2:0.
+`YCbCr 4:2:0` Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks timings as supporting only `YCbCr 4:2:0`.
 
 Constraint Set associated with these timings MUST have `urn:x-nmos:cap:format:color_sampling` equal to `YCbCr-4:2:0`.
 
-### Preference order
-
-If CTA-861 Extension Block is present and contains Video Format Preference Data Block (see [CTA-861][CTA-861] section 7.5.12), it MUST be used to fill `urn:x-nmos:cap:meta:preference`.
-
-Otherwise, the following preference order should be used:
-1. The 1st Detailed Timing Descriptor (Preferred Timing Mode).
-2. Other Detailed Timing Descriptors in the order listed in Base EDID.
-3. Any additional Detailed Timing Descriptors (priority is in the order listed) in CTA-861 Extension.
-4. Short Video Descriptors in the order listed in CTA-861.
-5. Any optional 3 Byte CVT Codes listed in Base EDID. Constraint Sets with _Preferred Vertical Rate_ MUST go first, then the rest in the order of descence of frame rate.
-6. Standard Timings listed in Base EDID.
-7. Established Timings listed in Base EDID.
-
 ## Audio Receivers
 
-If Basic Audio support bit is active in CTA Extension Header, audio receiver MUST have Receiver Caps.
+If Basic Audio support bit is active in CTA Extension Header, audio receiver MUST have Receiver Capabilities.
 
-If there is no any Short Audio Descriptors (see [CTA-861][CTA-861] section 7.5.2), it means 2-channel Linear PCM audio with 8 bit depth, so `caps` attribute of `media_type` MUST contain only `audio/L8`, `urn:x-nmos:cap:format:media_type` MUST be equal to `audio/L8` and `urn:x-nmos:cap:format:channel_count` MUST be equal to 2.
+When no descriptors are provided, the cabilities MUST contain:
 
-If there are Short Audio Descriptors, then each of them MUST be transformed into a Constraint Set.
+* `urn:x-nmos:cap:format:media_type` MUST be equal to `audio/L8`
+* `urn:x-nmos:cap:format:channel_count` MUST be equal to 2
 
-_Audio Format Code_ of each Short Audio Descriptor MUST be transformed into an IANA media type if possible, added to `caps` of `media_types` and `urn:x-nmos:cap:format:media_type` of the new Constraint Set. For Linear PCM format bit depth MUST be read from the third Short Audio Descriptors byte and used for building the IANA media type.
+### Short Audio Descriptors
 
-Number of channels MUST go to `urn:x-nmos:cap:format:channel_count`.
+If there are Short Audio Descriptors (see [CTA-861][CTA-861] section 7.5.2), then each of them MUST be transformed into a Constraint Set.
 
-All sampling frequencies MUST go to `urn:x-nmos:cap:format:sample_rate` as `enum`.
+* `urn:x-nmos:cap:format:media_type` MUST be determined with _Audio Format Code_
+  * Linear PCM bit depth MUST be the third Short Audio Descriptors byte
+* `urn:x-nmos:cap:format:channel_count` MUST be determined by _Number of Channels_
+* `urn:x-nmos:cap:format:sample_rate` MUST be filled with _Sampling Frequencies_
 
 [RFC-2119]: https://tools.ietf.org/html/rfc2119 "Key words for use in RFCs to Indicate Requirement Levels"
 [IS-04]: https://specs.amwa.tv/is-04/ "AMWA IS-04 NMOS Discovery and Registration Specification (Stable)"
 [BCP-004-01]: https://specs.amwa.tv/bcp-004-01/ "NMOS Receiver Capabilities"
 [E-EDID]: https://vesa.org/vesa-standards/ "VESA Enhanced Extended Display Identification Data Standard Release A, Revision 2"
+[DMT]: https://vesa.org/vesa-standards/ "VESA and Industry Standards and Guidelines for Computer Display Monitor Timing (DMT) Version 1.0, Rev. 12"
 [CTA-861]: https://shop.cta.tech/products/a-dtv-profile-for-uncompressed-high-speed-digital-interfaces-cta-861-g "A DTV Profile for Uncompressed High Speed Digital Interfaces (CTA-861-G)"

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -141,7 +141,7 @@ For example, given the bytes of Standard Timings were `D1 C0 01 01 01 01 01 01 0
 
 #### Detailed Timing Descriptors (18 Byte Descriptors)
 
-Defined in [E-EDID][E-EDID] section 3.10, there a 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value of `100`.
+Defined in [E-EDID][E-EDID] section 3.10, there a 4 possible descriptors which can be provided. The first, _Prefered Timing Mode_ is an obligation and MUST have a `urn:x-nmos:cap:meta:preference` value of `100`. Any additional Detailed Timing Descriptors in [CTA-861][CTA-861] Extension BLock (section 7.2.1) MUST follow the mapping.
 
 The mapping is defined in section 3.10.2 and is applied as follows:
 

--- a/docs/2.0. EDID to Receiver Caps mapping.md
+++ b/docs/2.0. EDID to Receiver Caps mapping.md
@@ -57,7 +57,7 @@ Each video timing SHOULD be present in the Receiver's Capabilities as a Constrai
 
 * `urn:x-nmos:cap:format:frame_width`
 * `urn:x-nmos:cap:format:frame_height`
-* `urn:x-nmos:cap:format:grain_rate` which MUST be the frame rate of the signal
+* `urn:x-nmos:cap:format:grain_rate` which MUST be the exact frame rate of the signal
 
 The timing descriptors MAY include one or more of the following mappings:
 

--- a/docs/3.0. Behaviour.md
+++ b/docs/3.0. Behaviour.md
@@ -20,7 +20,7 @@ Media description which describes a format acceptable for all Receivers implied 
 
 ## API Structure
 
-The API provides a mechanism to change the settings associated with logical Sources, Flows and Senders. Another use case is obtaining information about Sinks associated with Receivers. The UUIDs used to advertise Senders and Receivers in EDID Processing API must match those used in a corresponding IS-04 implementation.
+The API provides a mechanism to change the settings associated with logical Sources, Flows and Senders. Another use case is obtaining information about Sinks associated with Receivers. The UUIDs used to advertise Senders and Receivers in EDID Processing API MUST match those used in a corresponding IS-04 implementation.
 
 ### Senders
 
@@ -28,11 +28,11 @@ The API provides a mechanism to change the settings associated with logical Sour
 
 The initial state of Media Profiles of any Sender is empty. Creating a connection with such Sender via IS-05 doesn't involve NMOS EDID Connection Management.
 
-GET request returns the last successfully applied Media Profiles array.
+`GET` request returns the last successfully applied Media Profiles array.
 
-PUT request MUST be validated and if the Device fully supports the proposed media parameters, it initiates an attempt to reconfigure Device and update according Flow and/or Source and/or Sender values. If success, the GET operation MUST start returning the accepted Media Profiles array, otherwise an error MUST be returned and nothing changed.
+`PUT` request MUST be validated and if the Device fully supports the proposed media parameters, it initiates an attempt to reconfigure Device and update according Flow and/or Source and/or Sender values. If success, the GET operation MUST start returning the accepted Media Profiles array, otherwise an error MUST be returned and nothing changed.
 
-DELETE request MUST clear the last successfully applied Media Profiles array and NMOS EDID Connection Management MUST fall out of use and return to its initial state.
+`DELETE` request MUST clear the last successfully applied Media Profiles array and NMOS EDID Connection Management MUST fall out of use and return to its initial state.
 
 When the `media-profiles` structure changes as a consequence of PUT or DELETE (request is validated and accepted by the API server), then the associated IS-04 Sender MUST have its version updated (in registered mode this MUST update the registered resource).
 


### PR DESCRIPTION
- [x] Exact frame rate // Verify ST-2110-20
- [x] Links for `color_subsampling` // Verify ST-2110-20
- [x] In DMT the STD 2 byte codes -->always Progressive unless noted otherwise
   - From DMT section 1
   - > All [timings] listed in Table 1-1 are non-interlaced video timing modes - unless otherwise specified using the symbol “(Int.)”
   - :a: Sounds reasonable
- [x] CEA Extension DTD << Cut by accident

***

- [ ] New 5k Monitor use Extension DisplayID to advertise "best" since it's bigger than 4k