### PR TITLE
Remove waveform terms

### DIFF
--- a/docs/EDID to Receiver Caps Mapping.md
+++ b/docs/EDID to Receiver Caps Mapping.md
@@ -179,6 +179,8 @@ Video Data Block is defined in [CTA-861][CTA-861] section 7.5.1.
 
 It operates with Video Identification Codes (VICs), each of them is associated with a union of frame width, height and rate and interlace mode. This mapping is defined in [CTA-861][CTA-861] section 4.1.
 
+Some of VICs are marked as associated with two flavours of the same mode: with a frame rate that is an integer multiple of 6 Hz and a frame rate adjusted by a factor of 1000/1001. Such VICs MUST be described with `urn:x-nmos:cap:format:grain_rate` supporting the both frame rates.
+
 ### Color subsampling
 
 If EDID doesn't have the [CTA-861][CTA-861] Extension Block, color subsampling formats MUST be taken from Base EDID, otherwise from the Extenstion Block.
@@ -209,6 +211,10 @@ YCbCr 4:2:0 Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks video mod
 _Color Bit Depth_ of _Video Input Definition_ described in [E-EDID A2][E-EDID] section 3.6.1 MUST be transformed into `urn:x-nmos:cap:format:component_depth` and MUST be added to each Constraint Set.
 
 Vendor-Specific Data Block ([CTA-861][CTA-861] section 7.5.4) SHOULD be transformed into `urn:x-nmos:cap:format:component_depth` if contains related information.
+
+### Colorspace
+
+Colorimetry Data Block ([CTA-861][CTA-861] section 7.5.5) SHOULD be transformed into `urn:x-nmos:cap:format:colorspace` if contains related information.
 
 ## Audio Receivers
 

--- a/docs/EDID to Receiver Caps Mapping.md
+++ b/docs/EDID to Receiver Caps Mapping.md
@@ -179,7 +179,7 @@ Video Data Block is defined in [CTA-861][CTA-861] section 7.5.1.
 
 It operates with Video Identification Codes (VICs), each of them is associated with a union of frame width, height and rate and interlace mode. This mapping is defined in [CTA-861][CTA-861] section 4.1.
 
-Some of VICs are marked as associated with two flavours of the same mode: with a frame rate that is an integer multiple of 6 Hz and a frame rate adjusted by a factor of 1000/1001. Such VICs MUST be described with `urn:x-nmos:cap:format:grain_rate` supporting the both frame rates.
+Some of VICs are marked as associated with two flavours of the same mode: with a frame rate that is an integer multiple of 6 Hz and a frame rate adjusted by a factor of 1000/1001. Such VICs MUST be described with `urn:x-nmos:cap:format:grain_rate` supporting both frame rates.
 
 ### Color subsampling
 
@@ -214,7 +214,7 @@ Vendor-Specific Data Block ([CTA-861][CTA-861] section 7.5.4) SHOULD be transfor
 
 ### Colorspace
 
-Colorimetry Data Block ([CTA-861][CTA-861] section 7.5.5) SHOULD be transformed into `urn:x-nmos:cap:format:colorspace` if contains related information.
+Colorimetry Data Block ([CTA-861][CTA-861] section 7.5.5) SHOULD be transformed into `urn:x-nmos:cap:format:colorspace` with related information if present.
 
 ## Audio Receivers
 

--- a/docs/EDID to Receiver Caps Mapping.md
+++ b/docs/EDID to Receiver Caps Mapping.md
@@ -31,22 +31,20 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 If an [IS-04][IS-04] Video Receiver is associated with an Output which has an EDID, the optional mapping of the EDID supported video formats into Receiver's Capabilities SHALL be performed according to the rules below.
 
-### Video Timing Modes
+### Video Modes
 
-Video timing modes, described in [E-EDID][E-EDID], provide information about the video frame size and vertical rate. There are multiple blocks which keep information about these modes, each has its own mapping requirements.
+Video modes, described in [E-EDID][E-EDID], provide information about the video frame size and frame rate. There are multiple blocks which keep information about these modes, each has its own mapping requirements.
 
-Each video timing mode SHOULD be expressed in the Receiver's Capabilities as a separate Constraint Set or a part of a more common Constraint Set with non-empty
+Each video mode SHOULD be expressed in the Receiver's Capabilities as a separate Constraint Set or a part of a more common Constraint Set with non-empty
 
 - `urn:x-nmos:cap:format:frame_width`
 - `urn:x-nmos:cap:format:frame_height`
-- `urn:x-nmos:cap:format:grain_rate` which MUST reflect the exact frame rate of the signal
+- `urn:x-nmos:cap:format:grain_rate`
 
-The timing descriptors MAY include one or more of the following mappings:
+The video mode descriptors MAY include one or more of the following mappings:
 
 - `urn:x-nmos:cap:format:interlace_mode`
 - `urn:x-nmos:cap:meta:preference`
-
-Video timing modes with Reduced Blanking MAY be determined by the exact `urn:x-nmos:cap:format:grain_rate`.
 
 #### Established Timings I, II & III
 
@@ -202,9 +200,9 @@ This value MUST be transformed into `urn:x-nmos:cap:format:color_sampling` with 
 
 The supported color subsampling formats in the CTA Extension Header ([CTA-861][CTA-861] section 7.5) indicate `YCbCr-4:2:2` and `YCbCr-4:4:4` support in addition to `RGB`.
 
-YCbCr 4:2:0 Capability Map Data Block ([CTA-861][CTA-861] section 7.5.11) shows which timings support `YCbCr-4:2:0` in addition to subsampling formats listed in the CTA Extension Header. These timings MUST contain `YCbCr-4:2:0` within the possible values for `urn:x-nmos:cap:format:color_sampling` with associated Constraint Set.
+YCbCr 4:2:0 Capability Map Data Block ([CTA-861][CTA-861] section 7.5.11) shows which video modes support `YCbCr-4:2:0` in addition to subsampling formats listed in the CTA Extension Header. Constraint Sets associated with these video modes MUST contain `YCbCr-4:2:0` within the possible values for `urn:x-nmos:cap:format:color_sampling`.
 
-YCbCr 4:2:0 Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks timings as supporting only `YCbCr-4:2:0`. Constraint Set associated with these timings MUST have `urn:x-nmos:cap:format:color_sampling` limited to `YCbCr-4:2:0`.
+YCbCr 4:2:0 Video Data Block ([CTA-861][CTA-861] section 7.5.10) marks video modes as supporting only `YCbCr-4:2:0`. Constraint Sets associated with these video modes MUST have `urn:x-nmos:cap:format:color_sampling` limited to `YCbCr-4:2:0`.
 
 ### Color component depth
 


### PR DESCRIPTION
This PR removes waveform terms (such as "timing" and "reduced blanking") and takes into account colorspace and CTA-861-G VICs with double frame rate.